### PR TITLE
dependabotにDockerイメージ管理を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,11 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,6 @@ updates:
     schedule:
       interval: weekly
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directory: "/.github/workflows"
     schedule:
       interval: weekly


### PR DESCRIPTION
- docker compose対策
- github actions 対策

ベースイメージ更新に伴うPRを廃止したので、こちら側で変更を検知していく必要があります。